### PR TITLE
Use a secret to reference the AWS SDK account ID

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v1
         with:
           aws-region: eu-west-2
-          role-to-assume: arn:aws:iam::884096606738:role/ably-sdk-builds-sdk-upload-action
+          role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-sdk-upload-action
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
       - uses: actions/checkout@v2
       - name: Create test files for upload

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ steps:
   - uses: aws-actions/configure-aws-credentials@v1
     with:
       aws-region: eu-west-2
-      role-to-assume: arn:aws:iam::884096606738:role/ably-sdk-builds-<REPO-NAME>
+      role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-<REPO-NAME>
       role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
   - uses: ably/sdk-upload-action@v1
     with:
@@ -37,7 +37,7 @@ This action expects the calling repository to be configured to use [GitHub OIDC]
 - uses: aws-actions/configure-aws-credentials@v1
   with:
     aws-region: eu-west-2
-    role-to-assume: arn:aws:iam::884096606738:role/ably-sdk-builds-ably-js
+    role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-js
     role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 ```
 


### PR DESCRIPTION
It's not secret information, but makes it easier to migrate resources to a different AWS account in the future (something we'll likely be doing soon).