### PR TITLE
Replace sdk.ably.io with sdk.ably.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ steps:
 
 In the above example, `<REPO-NAME>` should be the Ably repository name (e.g. `ably-js`), and `githubToken` uses the `GITHUB_TOKEN` secret which is automatically supplied to GitHub runners so you don't need to do anything to access it.
 
-Artifacts generated from pull requests will be uploaded to `https://sdk.ably.io/builds/ably/${repository_name}/pull/${pull_number}/${artifactName}` and artifacts generated from pushes to the main branch will be uploaded to `https://sdk.ably.io/builds/ably/${repository_name}/main/${artifactName}`.
+Artifacts generated from pull requests will be uploaded to `https://sdk.ably.com/builds/ably/${repository_name}/pull/${pull_number}/${artifactName}` and artifacts generated from pushes to the main branch will be uploaded to `https://sdk.ably.com/builds/ably/${repository_name}/main/${artifactName}`.
 
 ## Permissions
 


### PR DESCRIPTION
It appears that sdk.ably.io no longer exists.