### PR TITLE
Remove deprecated S3 access method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## Version 2 (yet to be released)
+
+- Removes support for S3 Access Key to be used to directly specify the IAM user.
+  GitHub OIDC is now required.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,11 @@
 2. Run `npm install` which will update the version in `package-lock.json` and also reveal whether there are any dependency vulnerabilities to be fixed
 3. Run `npm run build` to compile the TypeScript source code in to JS (output will be in `lib/index.js`, ignored by git)
 4. Run `npm run package` to compile the JS from step 1 into a single file (output will be in the dist folder)
-5. Commit the changes to the dist folder from step 4
-6. Push a tag with the absolute new version number to GitHub, which must be in the form `v<major>.<minor>.<patch>` - e.g. `v1.3.0`
-7. Move the tag for the `major` version number to the same commit, which will be in the form `v<major>` - e.g. `v1`
+5. Commit the changes to the dist folder from step 4, alongside the version change from steps 1 and 2
+6. Update [`CHANGELOG.md`](CHANGELOG.md)
+7. Commit the change to the Changelog from step 6
+8. Push a tag with the absolute new version number to GitHub, which must be in the form `v<major>.<minor>.<patch>` - e.g. `v1.3.0`
+9. Move the tag for the `major` version number to the same commit, which will be in the form `v<major>` - e.g. `v1`
 
 Commits made in steps 1 thru 5 should ideally be pushed to a release branch, seeking approval from others to land to `main` (default) branch prior to adding and moving tags.
 

--- a/action.yml
+++ b/action.yml
@@ -8,12 +8,6 @@ runs:
   using: node16
   main: dist/index.js
 inputs:
-  s3AccessKeyId:
-    description: AWS IAM user's access key id.
-    required: true
-  s3AccessKey:
-    description: AWS IAM user's secret access key.
-    required: true
   sourcePath:
     description: Path to a directory containing the files to upload, relative to the root directory of the repository.
     required: true

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,14 +87,6 @@ const s3ClientConfig: S3ClientConfig = {
     region: 'eu-west-2',
 };
 
-if(core.getInput('s3AccessKeyId') && core.getInput('s3AccessKey')) {
-    core.warning('Setting s3AccessKeyId and s3AccessKey is deprecated, please switch to using the aws-actions/configure-aws-credentials action with GitHub OIDC.');
-    s3ClientConfig.credentials = {
-        accessKeyId: core.getInput('s3AccessKeyId'),
-        secretAccessKey: core.getInput('s3AccessKey')
-    };
-}
-
 const s3Client = new S3Client(s3ClientConfig);
 
 const upload = async (params: PutObjectCommandInput) => {


### PR DESCRIPTION
This change necessitates a bump to the `major` component of the version number for this action.

There are no SDK repositories using either `s3AccessKey` or `s3AccessKeyId` anymore, however we should evolve this action aligning with semantic versioning. SDK repositories can adopt `@v2` as they need to, perhaps to take advantage of newer features that will surely follow this change.