### PR TITLE
Make `artifactName` input optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,3 +4,4 @@
 
 - Removes support for S3 Access Key to be used to directly specify the IAM user.
   GitHub OIDC is now required.
+- Makes the `artifactName` Action input optional, allowing artifacts to be uploaded to the root of the deployment context.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ In the above example, `<REPO-NAME>` should be the Ably repository name (e.g. `ab
 - Artifacts generated from pushes to the main branch will be uploaded to `https://sdk.ably.com/builds/ably/${repository_name}/main/${artifactName}`.
 - Artifacts generated from a pushed tag will be uploaded to `https://sdk.ably.com/builds/ably/${repository_name}/tag/${tag_name}/${artifactName}`.
 
+If `artifactName` is not specified, or specified as an empty string, then artifacts are pushed to the root of the upload context (i.e. dropping `/${artifactName}` from the URL structures outlined above).
+
 ## Permissions
 
 ### AWS

--- a/action.yml
+++ b/action.yml
@@ -15,5 +15,9 @@ inputs:
     description: This should be a token with access to the repository scoped in as a secret. This will be available in the GitHub runner environment by default as `secrets.GITHUB_TOKEN`.
     required: true
   artifactName:
-    description: The name of the artifact to be uploaded, for example `docs`. This will be used as the directory name within S3 for uploaded artifacts.
-    required: true
+    description: |
+      The name of the artifact to be uploaded, for example `docs`.
+      If supplied then it is used as the directory name within S3 for the uploaded artifacts, as well as within the GitHub deployment environment name.
+      If not supplied or supplied as an empty string then the artifacts are uploaded to S3 at root for this deployment context.
+    required: false
+    default: ''

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,7 @@ const ref = createRef(githubRef)
 
 const s3BucketName = 'sdk.ably.com';
 const sourcePath = path.resolve(core.getInput('sourcePath'));
-const artifactName = core.getInput('artifactName');
+const artifactName = core.getInput('artifactName').trim(); // empty string indicates no value, i.e. artifact name not specified
 
 let githubDeploymentRef: string;
 let s3KeyPrefix = `builds/${context.repo.owner}/${context.repo.repo}/`;
@@ -76,8 +76,11 @@ if (context.eventName === 'pull_request') {
     core.setFailed("Error: this action can only be ran on a pull_request, a push to the 'main' branch, or a push of a tag");
     process.exit(1);
 }
-s3KeyPrefix += ('/' + artifactName);
-githubEnvironmentName += ('/' + artifactName);
+
+if (artifactName.length > 0) {
+  s3KeyPrefix += ('/' + artifactName);
+  githubEnvironmentName += ('/' + artifactName);
+}
 
 core.debug(`S3 Key Prefix: ${s3KeyPrefix}`);
 core.debug(`GitHub Environment Name: ${githubEnvironmentName}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,11 @@ const ref = createRef(githubRef)
 
 const s3BucketName = 'sdk.ably.com';
 const sourcePath = path.resolve(core.getInput('sourcePath'));
-const artifactName = core.getInput('artifactName').trim(); // empty string indicates no value, i.e. artifact name not specified
+
+// Optional artifactName:
+// - The getInput() method calls trim() for us by default (trimWhitespace: true)
+// - Empty string indicates no value, i.e. artifact name not specified
+const artifactName = core.getInput('artifactName');
 
 let githubDeploymentRef: string;
 let s3KeyPrefix = `builds/${context.repo.owner}/${context.repo.repo}/`;


### PR DESCRIPTION
Allowing artifacts to be uploaded to the root of this deployment context.

There are times when there is no need for an intermediary folder, and coming up with that folder name would produce repetition or 'noise', being superfluous to requirements.