### PR TITLE
Enforce that required inputs are supplied

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ if (typeof githubRef !== 'string') {
     process.exit(1);
 }
 
-const githubToken = core.getInput('githubToken');
+const githubToken = core.getInput('githubToken', {required: true});
 const octokit = getOctokit(githubToken);
 
 const githubEvent = JSON.parse(fs.readFileSync(githubEventPath, 'utf8'));
@@ -54,7 +54,7 @@ const createRef = (githubRef: string) => {
 const ref = createRef(githubRef)
 
 const s3BucketName = 'sdk.ably.com';
-const sourcePath = path.resolve(core.getInput('sourcePath'));
+const sourcePath = path.resolve(core.getInput('sourcePath', {required: true}));
 
 // Optional artifactName:
 // - The getInput() method calls trim() for us by default (trimWhitespace: true)


### PR DESCRIPTION
The values of `required` that we specify in `action.yml` represent our declared interface, but they alone (when `true`) are not enough to make the action fail if those inputs are not supplied.

This change corrects that, passing the required option to the `getInput()` core actions API to ask it to police this for us.