### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -6,9 +6,13 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
 
       - name: Read Tool Versions
         id: tool-versions

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           persist-credentials: false
 
@@ -22,7 +22,7 @@ jobs:
         id: tool-versions
         run: echo "::set-output name=nodejs::$(sed -nr 's/nodejs ([0-9]+)/\1/p' .tool-versions)"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # v2
         with:
           node-version: ${{ steps.tool-versions.outputs.nodejs }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
 
+permissions: {}
+
 jobs:
   # Test that this action works with AWS credentials provided by the
   # aws-actions/configure-aws-credentials action using GitHub OIDC.
@@ -12,6 +14,7 @@ jobs:
   test-oidc:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       deployments: write
       id-token: write
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,8 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-sdk-upload-action
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
       - uses: actions/checkout@v2
+        with:
+          persist-credentials: false
       - name: Create test files for upload
         run: |
           mkdir -p test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,12 +19,12 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-sdk-upload-action
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           persist-credentials: false
       - name: Create test files for upload


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflows in this repo, addressing findings from a workflow security audit. Changes are split into three commits, one per finding type:

- Disable credential persistence on `actions/checkout` steps so the default `GITHUB_TOKEN` is not left in the local git config after checkout.
- Scope each workflow's permissions explicitly: top-level `permissions: {}`, with each job granted only the `GITHUB_TOKEN` scopes it actually needs (`contents: read` for both jobs; `deployments: write` and `id-token: write` retained on the OIDC test job).
- Pin all third-party actions to commit SHAs (with the tag preserved as a trailing comment) so an upstream tag move can't silently change what runs in CI.

No behavioural changes intended — the workflows run the same checks against the same inputs.